### PR TITLE
Fix g++ and LONG_MAX issue

### DIFF
--- a/align/Amap.cc
+++ b/align/Amap.cc
@@ -23,6 +23,8 @@
 #include <cstdlib>
 #include <cerrno>
 #include <iomanip>
+#include <cstring>  //BUG strcmp
+#include <climits> //BUG LONG_MAX https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=413477
 
 string parametersInputFilename = "";
 string parametersOutputFilename = "no training";


### PR DESCRIPTION
It was impossible to compile with ```make``` on Ubuntu with G++ version 7.3.0

It was needed to add cstring to be able to use the ```strcmp``` operator and climits for the constants LONG_MAX,...